### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ $ tag unmark <path>
 
 ### Delete a tag from all paths
 ```sh
-$ tag deltag <path>
+$ tag deltag <tag>
 ```


### PR DESCRIPTION
This fixes a critical typo in the README. This fix should reduce the confusion some new users may face while migrating to this tag system. 